### PR TITLE
Rotating Hands, Desktop Widescreen, & Less Crowding

### DIFF
--- a/src/games/zooparade/board.tsx
+++ b/src/games/zooparade/board.tsx
@@ -79,7 +79,7 @@ export class Board extends React.Component<IBoardProps,  {}> {
                 <BToken treats={this.props.G.treats} countdown={this.props.G.countdown}></BToken>
                 <BDeck cardsLeft={this.props.G.deckindex}></BDeck>
               </div>
-            <div>
+            <div style={{display: 'flex', flexDirection: 'column', maxWidth: '55px'}}>
               <BPiles piles={this.props.G.piles}
                           keyPropagation={"Board"}
                           ></BPiles>

--- a/src/games/zooparade/board.tsx
+++ b/src/games/zooparade/board.tsx
@@ -35,9 +35,9 @@ export class Board extends React.Component<IBoardProps,  {}> {
     return (
       <GameLayout
           gameArgs={this.props.gameArgs}
+          allowWiderScreen={true}
           >
-          <div /* wrapper - not sure if this is necessary */
-            style={{display: 'flex'}}>
+          <div style={{display: 'flex'}}>
             <div>
                 { rotatedHands.map(hand => {
                       let index = hand.player;

--- a/src/games/zooparade/board.tsx
+++ b/src/games/zooparade/board.tsx
@@ -28,6 +28,9 @@ export class Board extends React.Component<IBoardProps,  {}> {
 
     var me = this.props.playerID ? parseInt(this.props.playerID) : 1 // TODO : Local Fix - defaults to player 1
     var playerID = this.props.playerID ? this.props.playerID : "1" // TODO : Local Fix
+    
+    let hands = this.props.G.hands;
+    let rotatedHands = hands.slice(me + 1, hands.length).concat(hands.slice(0, me + 1));
 
     return (
       <GameLayout
@@ -36,21 +39,23 @@ export class Board extends React.Component<IBoardProps,  {}> {
           <div /* wrapper - not sure if this is necessary */
             style={{display: 'flex'}}>
             <div>
-                { this.props.G.hands
-                    .filter(hand => hand.player !== me)
-                    .map(hand => {
+                { rotatedHands.map(hand => {
                       let index = hand.player;
                       return (
                         <div key={"Board" + index.toString()}
                              style={handStyle}>
-                            <BButtons onHintColor={(value: number) => {this.props.moves.moveHintColor(index, value)}}
-                                      onHintValue={(value: number) => {this.props.moves.moveHintValue(index, value)}}
-                                      myTurn={this.props.ctx.currentPlayer === playerID}
-                                      keyPropagation={"Board" + index.toString()}
-                                      > 
-                            </BButtons>
+                            {index === me ?
+                              <><hr />Your Hand:</>
+                            :
+                              <BButtons onHintColor={(value: number) => {this.props.moves.moveHintColor(index, value)}}
+                                        onHintValue={(value: number) => {this.props.moves.moveHintValue(index, value)}}
+                                        myTurn={this.props.ctx.currentPlayer === playerID}
+                                        keyPropagation={"Board" + index.toString()}
+                                        > 
+                              </BButtons>
+                            }
                             <BHand hand={ hand } 
-                                   me={ false } 
+                                   me={me === index} 
                                    onPlay={(id: number) => {this.props.moves.movePlay(id)}}
                                    onTrash={(id: number) => {this.props.moves.moveDiscard(id)}}
                                    myTurn={this.props.ctx.currentPlayer === playerID}
@@ -60,18 +65,6 @@ export class Board extends React.Component<IBoardProps,  {}> {
                         </div>
                         )
                 })}
-                <div key={"Board" + me.toString()}
-                     style={handStyle}>
-                    <hr /><br />Your Hand:
-                    <BHand hand={ this.props.G.hands[me] } 
-                           me={ true } 
-                           onPlay={(id: number) => {this.props.moves.movePlay(id)}}
-                           onTrash={(id: number) => {this.props.moves.moveDiscard(id)}}
-                           myTurn={this.props.ctx.currentPlayer === playerID}
-                           keyPropagation={"Board" + me.toString()}
-                           >
-                    </BHand>
-                </div>
             </div>
             <div>
                 {

--- a/src/games/zooparade/components/bcard.css
+++ b/src/games/zooparade/components/bcard.css
@@ -1,27 +1,77 @@
-.image {
-    position: absolute;
+.card {
+  width: 100%;
+  min-width: 40px;
+  max-width: 85px;
+  
+  box-sizing: border-box;
+  display: inline-block;
+  overflow: hidden;
+  position: relative;
+  
+  background: no-repeat center / contain;
+  
 }
 
-h2 {
-    position: absolute;
-    top: 37%;
-    left: 46%;
-    font-size: 60pt;
-    color: #000;
-}
-h3 {
-    position: absolute;
-    top: -10%;
-    left: 80%;
-    font-size: 60pt;
-    color: #000;
+.card > img {
+  width: 100%;
 }
 
-h4 {
-    position: absolute;
-    top: -15%;
-    left: 10%;
-    font-size: 60pt;
-    color: #000;
+.card > span {
+  position: absolute;
+  
+  top: 7%;
+  right: 17%;
+  font-size: 45px;
+  line-height: 1;
+  
+  font-weight: bold;
+  color: #572511;
 }
 
+/*
+.green {
+  background-image: url('./media/green.png');
+}
+.green_with {
+  background-image: url('./media/green_with.png');
+}
+
+.gray {
+  background-image: url('./media/gray.png');
+}
+.gray_with {
+  background-image: url('./media/gray_with.png');
+}
+
+.brown {
+  background-image: url('./media/brown.png');
+}
+.brown_with {
+  background-image: url('./media/brown_with.png');
+}
+
+.yellow {
+  background-image: url('./media/yellow.png');
+}
+.yellow_with {
+  background-image: url('./media/yellow_with.png');
+}
+
+.blue {
+  background-image: url('./media/blue.png');
+}
+.blue_with {
+  background-image: url('./media/blue_with.png');
+}
+
+.empty {
+  background-image: url('./media/empty.png');
+}
+
+.white {
+  background-image: url('./media/white.png');
+}
+
+.deck {
+  background-image: url('./media/deck.png');
+} */

--- a/src/games/zooparade/components/bcard.tsx
+++ b/src/games/zooparade/components/bcard.tsx
@@ -1,6 +1,22 @@
 import React from 'react';
 import { ICard } from '../interfaces';
 
+import green from './media/green.png';
+import green_with from './media/green_with.png';
+import gray from './media/gray.png';
+import gray_with from './media/gray_with.png';
+import brown from './media/brown.png';
+import brown_with from './media/brown_with.png';
+import yellow from './media/yellow.png';
+import yellow_with from './media/yellow_with.png';
+import blue from './media/blue.png';
+import blue_with from './media/blue_with.png';
+import empty from './media/empty.png';
+import white from './media/white.png';
+import deck from './media/deck.png';
+
+import style from './bcard.css';
+
 interface InnerWrapper {
     card : ICard, // if null, show back of card. 
     empty: number , // If -1, then 'empty', if 0-4 base color
@@ -17,87 +33,60 @@ export class BCard extends React.Component< InnerWrapper, {}> {
             cardValue = "";
             switch (this.props.empty) {
               case 0:
-                image = require('./media/green.png');
+                image = green;
                 break;
               case 1:
-                image = require('./media/gray.png');
+                image = gray;
                 break;
               case 2:
-                image = require('./media/brown.png');
+                image = brown;
                 break;
               case 3:
-                image = require('./media/yellow.png');
+                image = yellow;
                 break;
               case 4:
-                image = require('./media/blue.png');
+                image = blue;
                 break;
               case -1:
-                image = require('./media/empty.png');
+                image = empty;
                 break;
               case -2:
-                image = require('./media/deck.png');
+                image = deck;
                 break;
             }
         } else if (!this.props.card) {
             // Card is null, so its hidden
             cardValue = ""
-            image = require('./media/white.png');
+            image = white;
         } else {
             cardValue = String(this.props.card.value !== null ? this.props.card.value : "");
             switch (this.props.card.color) {
               case 0:
-                image = require('./media/green_with.png');
+                image = green_with;
                 break;
               case 1:
-                image = require('./media/gray_with.png');
+                image = gray_with;
                 break;
               case 2:
-                image = require('./media/brown_with.png');
+                image = brown_with;
                 break;
               case 3:
-                image = require('./media/yellow_with.png');
+                image = yellow_with;
                 break;
               case 4:
-                image = require('./media/blue_with.png');
+                image = blue_with;
                 break;
               case -1:
-                image = require('./media/deck.png');
+                image = deck;
                 break;
             }
         }
 
         return (
-            <div 
-              className="image"
-              style = {{
-                        width: '56px',
-                        height: '88.9px',
-                        boxSizing: 'border-box',
-                        display: 'inline-block',
-                        overflow: 'hidden',
-                        background: `url(${image}) no-repeat center / contain`,
-                        padding: '5px 9px',
-                        fontSize: '1.8em',
-                        fontWeight: 'bold',
-                        color: '#572511',
-                        textAlign: 'right'
-              }}
-              >
-                { cardValue }
+            <div className={style.card}>
+                <img src={image} />
+                <span>{ cardValue }</span>
             </div>
         )
     }
 }
-
-// const styles = {
-//     container: {
-//       position: 'absolute',
-//       top: 0,
-//       left: 0,   
-//       width: '100%',
-//       height: '100%',
-//     },
-//     image: {  
-//       flex: 1,  
-//     }
-//   };

--- a/src/games/zooparade/components/bhand.css
+++ b/src/games/zooparade/components/bhand.css
@@ -2,7 +2,8 @@
   display: grid;
   /* grid-template-columns: repeat(auto-fill, minmax(55px, 85px));
   min-width: 300px; */
-  width: min(60vw, 450px);
+  width: 100%;
+  max-width: 450px;
   grid-template-columns: repeat(auto-fit, minmax(55px, 1fr));
   justify-content: center;
   gap: 5px;

--- a/src/games/zooparade/components/bhand.css
+++ b/src/games/zooparade/components/bhand.css
@@ -1,0 +1,22 @@
+.hand {
+  display: grid;
+  /* grid-template-columns: repeat(auto-fill, minmax(55px, 85px));
+  min-width: 300px; */
+  width: min(60vw, 450px);
+  grid-template-columns: repeat(auto-fit, minmax(55px, 1fr));
+  justify-content: center;
+  gap: 5px;
+  margin: 0 auto;
+}
+
+.card-column {
+  max-width: 85px;
+}
+
+.hints {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, 15px);
+  justify-content: center;
+  gap: 2.5px;
+  margin-bottom: 2.5px;
+}

--- a/src/games/zooparade/components/bhand.tsx
+++ b/src/games/zooparade/components/bhand.tsx
@@ -4,6 +4,8 @@ import { BCard } from './bcard';
 import { BHint } from './bhint';
 import { BPlay } from './bplay';
 
+import style from './bhand.css';
+
 interface InnerWrapper {
     hand: IHand ;
     me: boolean ;
@@ -15,75 +17,62 @@ interface InnerWrapper {
     keyPropagation: string;
 }
 
-let handStyle = {
-  display: "flex"
-}
-
-let cardColStyle = {
-  display: "inline-block"
-}
-
 export class BHand extends React.Component< InnerWrapper, {}> {
     render() {
         var hand = this.props.hand
         return (
-                    <div
-                      //class="hand"
-                      style={handStyle}
-                      >
-                        { hand.cards.map((card, card_index) => 
-                            {
-                                // If player, then 'overwrite' the card with the info from the hint
-                                const hint =  this.props.hand.hints[card_index]
+            <div className={style.hand}>
+                { hand.cards.map((card, card_index) => 
+                    {
+                        // If player, then 'overwrite' the card with the info from the hint
+                        const hint =  this.props.hand.hints[card_index]
 
-                                var newCard : ICard
-                                var empty : number = null
+                        var newCard : ICard
+                        var empty : number = null
 
-                                if (this.props.me) {
-                                    newCard = { id: -1, 
-                                                value: hint.value.indexOf(1) !== -1 ? hint.value.indexOf(1) : null,
-                                                color: hint.color.indexOf(1) !== -1 ? hint.color.indexOf(1) : -1}
-                                } else {
-                                    // TODO: Error here if pick up empty!
-                                    if (card === null) { // This can happen if you pick up the last card.
-                                        newCard = null
-                                        empty = -1
-                                    } else {
-                                        newCard = { id: card.id, value: card.value, color: card.color }
-                                    }
-                                }
-
-                                return (
-                                    <div 
-                                      key={this.props.keyPropagation + "BHand" + card_index.toString()}
-                                      //class="card_column"
-                                      style={cardColStyle}
-                                      >
-                                        <BHint
-                                            hint={ hint } 
-                                            keyPropagation={this.props.keyPropagation + "BHand" + card_index.toString()}
-                                            >
-                                        </BHint>
-                                        <BCard 
-                                            card={ newCard }
-                                            empty = { empty } 
-                                            >
-                                        </BCard>
-                                        { this.props.me 
-                                            ? 
-                                            <BPlay onPlay={() => {this.props.onPlay(card_index)}} 
-                                                   onTrash={() => {this.props.onTrash(card_index)}} 
-                                                   myTurn={this.props.myTurn}
-                                                   > 
-                                                   </BPlay> 
-                                            : 
-                                            null
-                                        }
-                                    </div>
-                                )
-                            })
+                        if (this.props.me) {
+                            newCard = { id: -1, 
+                                        value: hint.value.indexOf(1) !== -1 ? hint.value.indexOf(1) : null,
+                                        color: hint.color.indexOf(1) !== -1 ? hint.color.indexOf(1) : -1}
+                        } else {
+                            // TODO: Error here if pick up empty!
+                            if (card === null) { // This can happen if you pick up the last card.
+                                newCard = null
+                                empty = -1
+                            } else {
+                                newCard = { id: card.id, value: card.value, color: card.color }
+                            }
                         }
-                    </div>
+
+                        return (
+                            <div  className={style.card_column}
+                                  key={this.props.keyPropagation + "BHand" + card_index.toString()}
+                              >
+                                <BHint
+                                    hint={ hint } 
+                                    keyPropagation={this.props.keyPropagation + "BHand" + card_index.toString()}
+                                    >
+                                </BHint>
+                                <BCard 
+                                    card={ newCard }
+                                    empty = { empty } 
+                                    >
+                                </BCard>
+                                { this.props.me 
+                                    ? 
+                                    <BPlay onPlay={() => {this.props.onPlay(card_index)}} 
+                                           onTrash={() => {this.props.onTrash(card_index)}} 
+                                           myTurn={this.props.myTurn}
+                                           > 
+                                           </BPlay> 
+                                    : 
+                                    null
+                                }
+                            </div>
+                        )
+                    })
+                }
+            </div>
         )
     }
 }

--- a/src/games/zooparade/components/bhint.tsx
+++ b/src/games/zooparade/components/bhint.tsx
@@ -2,21 +2,18 @@ import React from 'react';
 import { IHint } from '../interfaces';
 import { BHintIcon } from './bhinticon';
 
+import style from './bhand.css';
+
 interface InnerWrapper {
     hint: IHint;
 
     keyPropagation: string;
 }
 
-let hintRowStyle = {
-  display: 'flex'
-}
-
 export class BHint extends React.Component< InnerWrapper, {}> {
     render() {
         return (
-            <div>
-              <div style={hintRowStyle}>
+            <div className={style.hints}>
                 { this.props.hint.color.map((value: number , index: number ) =>
                         {
                             return <BHintIcon
@@ -25,8 +22,6 @@ export class BHint extends React.Component< InnerWrapper, {}> {
                                      ></BHintIcon>
                         })
                 }
-              </div>
-              <div style={hintRowStyle}>
                 { this.props.hint.value.map((value: number , index: number ) =>
                         {
                             return <BHintIcon
@@ -35,7 +30,6 @@ export class BHint extends React.Component< InnerWrapper, {}> {
                                      ></BHintIcon>
                         })
                 }
-              </div>
             </div>
         )
     }


### PR DESCRIPTION
- Changes board.tsx to rotate the hands so that each player sees theirs at the bottom, while not losing their place in the turn order.
- Found and enabled the flag that - where possible - will make the game widescreen. This does mean we can show everything at once on desktop (without it becoming too crowded), but it also means we will have to have a second version of the layout for mobiles etc.
  > I've done some work on another branch of my fork (https://github.com/DanielSherlock/FreeBoardGames.org/tree/zp-layout-test) that shows how I think it might work. It has space for the fully-detailed discard pile (which would be expandable on mobile), and room for large cards and hint buttons - even with lots of players or on mobile. If you want to try it out, I recommend you also make a test branch in your fork to merge into, so the changes can be easily dumped if necessary.
- Made big improvements to the hands layout: cards are more adaptable, spaced things out a little, etc.